### PR TITLE
Add history-tags

### DIFF
--- a/src/components/App.spec.js
+++ b/src/components/App.spec.js
@@ -43,7 +43,11 @@ describe('Local Storage', () => {
 describe('Wheel', () => {
   it('starts spinning the wheel on spin button click', () => {
     render(<App />)
+
+    expect(screen.queryByTestId('loadingCircles')).not.toBeInTheDocument()
+
     userEvent.click(screen.getByRole('button', { name: /spin/i }))
+
     expect(screen.getByTestId('loadingCircles')).toBeVisible()
   })
 })

--- a/src/components/App.spec.js
+++ b/src/components/App.spec.js
@@ -42,9 +42,8 @@ describe('Local Storage', () => {
 
 describe('Wheel', () => {
   it('starts spinning the wheel on spin button click', () => {
-    const SPINNING_PROMPT = '...'
     render(<App />)
     userEvent.click(screen.getByRole('button', { name: /spin/i }))
-    expect(screen.getByTestId('prompt').textContent).toBe(SPINNING_PROMPT)
+    expect(screen.getByTestId('loadingCircles')).toBeVisible()
   })
 })

--- a/src/components/History.jsx
+++ b/src/components/History.jsx
@@ -5,8 +5,8 @@ export default function History({ history }) {
     <Wrapper>
       <h2>Spin History</h2>
       <HistoryEntries data-testid="history">
-        {history.map(spin => (
-          <Entry>{spin}</Entry>
+        {history.map(previousPrompt => (
+          <Entry>{previousPrompt}</Entry>
         ))}
       </HistoryEntries>
     </Wrapper>

--- a/src/components/History.jsx
+++ b/src/components/History.jsx
@@ -2,13 +2,29 @@ import styled from 'styled-components/macro'
 
 export default function History({ history }) {
   return (
-    <Entries data-testid="history">
+    <Wrapper>
       <h2>Spin History</h2>
-      {history.join(', ')}
-    </Entries>
+      <HistoryEntries data-testid="history">
+        {history.map(spin => (
+          <Entry>{spin}</Entry>
+        ))}
+      </HistoryEntries>
+    </Wrapper>
   )
 }
 
-const Entries = styled.div`
+const Wrapper = styled.div`
   padding: 2em 1em;
+`
+
+const HistoryEntries = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`
+
+const Entry = styled.div`
+  padding: 5px 15px;
+  border-radius: 5px;
+  background: #e4e4e4;
 `

--- a/src/components/LoadingCircles.jsx
+++ b/src/components/LoadingCircles.jsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components/macro'
 
-export default function LoadingCircles() {
+function LoadingCircles() {
   return (
-    <Wrapper>
+    <Wrapper data-testid="loadingCircles">
       <div className="circle"></div>
       <div className="circle"></div>
       <div className="circle"></div>
@@ -19,8 +19,8 @@ const Wrapper = styled.div`
     position: relative;
     border-radius: 50%;
     background: #000;
-    width: 10px;
-    height: 10px;
+    width: 7px;
+    height: 7px;
     animation: bounce 0.5s alternate infinite ease;
   }
 
@@ -41,3 +41,4 @@ const Wrapper = styled.div`
     }
   }
 `
+export default LoadingCircles


### PR DESCRIPTION
## Value Proposition
As a **user**,
I would like to see my **previous prompts as tags**,
so It becomes easier to **distinguish them from each other**
## Acceptance Criteria
- [x] History is no longer converted to a comma-separated string
- [x] Each history entry lives in its own div, rendered with padding and background-color
### Bonus Feature
- [x] There is a loading animation for prompts while the wheel is spinning